### PR TITLE
退会処理　ヘッダーレイアウトの作成

### DIFF
--- a/app/controllers/public/members_controller.rb
+++ b/app/controllers/public/members_controller.rb
@@ -2,28 +2,35 @@ class Public::MembersController < ApplicationController
   def show
     @member = Member.find(params[:id])
   end
-  
+
   def edit
     @member = Member.find(params[:id])
   end
-  
+
   def update
     @member = Member.find(params[:id])
-    @member.update(member_params)
-    redirect_to member_path(@member)
+    if @member.update(member_params)
+      redirect_to member_path(@member.id)
+    else
+      render "edit"
+    end
   end
-  
+
   def unsubscribe
-    
   end
-  
+
   def withdraw
+    @member = current_member
+    @member.update(is_deleted: true)
+    reset_session
+    flash[:nitice] = "またのご利用をお待ちしております。"
+    redirect_to root_path
   end
-  
+
   private
-  
+
   def member_params
   params.require(:member).permit(:last_name,:first_name,:last_name_kana,:first_name_kana,:post_number,:address,:phone_number,:email,:is_deleted)
-  end 
+  end
 
 end

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -2,6 +2,8 @@
 
 class Public::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
+  before_action :member_state, only: [:create]
+  
   def after_sign_in_path_for(resource)
     root_path
   end
@@ -23,8 +25,18 @@ class Public::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  # protected
-
+  protected
+  
+  def member_state
+    @member = Member.find_by(email: params[:member][:email])
+    if @member
+      if @member.valid_password?(params[:member][:password]) && (@member.is_deleted == false)
+        flash[:notice] = "既に退会されています。再度ご登録をお願いします。"
+        redirect_to new_member_registration_path
+      else
+      end
+    end
+  end
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -8,4 +8,12 @@ class Member < ApplicationRecord
   has_many :oders, dependent: :destroy
   has_many :addresses, dependent: :destroy
   validates :is_deleted, inclusion: { in: [true, false] }
+  validates :last_name,:first_name,:address, presence: true,
+    length: {in: 1..20 }
+  validates :last_name_kana,:first_name_kana, format: {with: /\A[ァ-ヶー－]+\z/ , message: "カタカナで入力してください。"},
+    length: {in: 1..20 }
+  validates :post_number, format: {with: /\A\d{7}\z/ , message: "ハイフンなしの７桁で入力してください。"}
+  def active_for_authentication?
+    super && (is_deleted == false)
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,57 +12,59 @@
 
   <body>
     <header>
-      <div class="container bg-light">
-        <a class="navbar-brand p-3" href="/"><%= image_tag('logo.png', :size =>'80x80') %></a>
-        <div class="row justify-content-end" >
-          <% if member_signed_in? %>
-          <button class= "btn btn-outline-secondary">
-            <%= link_to "マイページ", member_path(current_member.id), class: "text-dark" %>
-          </button>
-          <button class= "btn btn-outline-secondary">
-            <%= link_to "商品一覧", items_path, class: "text-dark" %>
-          </button>
-          <button class= "btn btn-outline-secondary">
-            <%= link_to "カート", cart_items_path(current_member.id), class: "text-dark" %>
-          </button>
-          <button class= "btn btn-outline-secondary">
-            <%= link_to "ログアウト", destroy_member_session_path,method: :delete, class: "text-dark" %>
-          </button>
-          <% elsif admin_signed_in? %>
-          <button class= "btn btn-outline-secondary">
-            <%= link_to "商品一覧", admin_items_path, class: "text-dark" %>
-          </button>
-          <button class= "btn btn-outline-secondary">
-            <%= link_to "会員一覧", admin_members_path, class: "text-dark" %>
-          </button>
-          <button class= "btn btn-outline-secondary">
-            <%= link_to "注文履歴一覧", admin_root_path, class: "text-dark" %>
-          </button>
-          <button class= "btn btn-outline-secondary">
-            <%= link_to "ジャンル一覧", admin_genres_path, class: "text-dark" %>
-          </button>
-          <button class= "btn btn-outline-secondary">
-            <%= link_to "ログアウト", destroy_admin_session_path,method: :delete, class: "text-dark" %>
-          </button>
-          <% else %>
-          <button class= "btn btn-outline-secondary">
-            <%= link_to "About", about_path, class: "text-dark" %>
-          </button>
-          <button class= "btn btn-outline-secondary">
-            <%= link_to "商品一覧", items_path, class: "text-dark" %>
-          </button>
-          <button class= "btn btn-outline-secondary">
-            <%= link_to "新規登録", new_member_registration_path, class: "text-dark" %>
-          </button>
-          <button class= "btn btn-outline-secondary">
-            <%= link_to "ログイン", new_member_session_path, class: "text-dark" %>
-          </button>
-          <% end %>
+      <div class="container-fluid bg-light">
+        <div class="row justify-content-between">
+          <a class="navbar-brand col-auto mr-auto p-3 m-0" href="/"><%= image_tag('logo.png', :size =>'80x80') %></a>
+          <div class="col-md-lg-auto mr-3 align-self-center">
+            <% if member_signed_in? %>
+            <button class= "btn btn-outline-secondary mr-3">
+              <%= link_to "マイページ", member_path(current_member.id), class: "text-dark" %>
+            </button>
+            <button class= "btn btn-outline-secondary mr-3">
+              <%= link_to "商品一覧", items_path, class: "text-dark" %>
+            </button>
+            <button class= "btn btn-outline-secondary mr-3">
+              <%= link_to "カート", cart_items_path(current_member.id), class: "text-dark" %>
+            </button>
+            <button class= "btn btn-outline-secondary">
+              <%= link_to "ログアウト", destroy_member_session_path,method: :delete, class: "text-dark" %>
+            </button>
+            <% elsif admin_signed_in? %>
+            <button class= "btn btn-outline-secondary mr-3">
+              <%= link_to "商品一覧", admin_items_path, class: "text-dark" %>
+            </button>
+            <button class= "btn btn-outline-secondary mr-3">
+              <%= link_to "会員一覧", admin_members_path, class: "text-dark" %>
+            </button>
+            <button class= "btn btn-outline-secondary mr-3">
+              <%= link_to "注文履歴一覧", admin_root_path, class: "text-dark" %>
+            </button>
+            <button class= "btn btn-outline-secondary mr-3">
+              <%= link_to "ジャンル一覧", admin_genres_path, class: "text-dark" %>
+            </button>
+            <button class= "btn btn-outline-secondary">
+              <%= link_to "ログアウト", destroy_admin_session_path,method: :delete, class: "text-dark" %>
+            </button>
+            <% else %>
+            <button class= "btn btn-outline-secondary mr-3">
+              <%= link_to "About", about_path, class: "text-dark" %>
+            </button>
+            <button class= "btn btn-outline-secondary mr-3">
+              <%= link_to "商品一覧", items_path, class: "text-dark" %>
+            </button>
+            <button class= "btn btn-outline-secondary mr-3">
+              <%= link_to "新規登録", new_member_registration_path, class: "text-dark" %>
+            </button>
+            <button class= "btn btn-outline-secondary">
+              <%= link_to "ログイン", new_member_session_path, class: "text-dark" %>
+            </button>
+            <% end %>
+          </div>
         </div>
       </div>
     </header>
-    <footer></footer>
-
+    <%= flash[:notice] %>
     <%= yield %>
+    <footer></footer>
   </body>
 </html>

--- a/app/views/public/homes/about.html.erb
+++ b/app/views/public/homes/about.html.erb
@@ -1,7 +1,6 @@
 <main>
-  <p></p>
-  <div class="conteiner">
-    <div class="row">
+  <div class="container">
+    <div class="row-mt-5">
       <h1 class="mx-auto center-block">
         <strong>About</strong>
       </h1>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -1,6 +1,6 @@
 <main>
   <p></p>
-  <div class="conteiner">
+  <div class="container">
     <div class="row">
       <div class="col-2 text-center">
         ジャンル検索

--- a/app/views/public/members/edit.html.erb
+++ b/app/views/public/members/edit.html.erb
@@ -1,73 +1,65 @@
-<% if false %>
+<%= form_with model:@member, local:true do |f| %>
 <table>
   <tbody>
-    <%= form_with(model: [:admin, @member],local:true) do |f| %>
-      <tr>
-        <td>
-          <form class="form-inline">
-          <div class="form-group">
-            <label>氏名</label>
-              <%= f.text_field :last_name %>
-              <%= f.text_field :first_name %>
-          </div>
-          </form>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <form class="form-inline">
-          <div class="form-group">
-            <label>フリガナ</label>
-              <%= f.text_field :last_name_kana %>
-              <%= f.text_field :first_name_kana %>
-          </div>
-          </form>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div class="form-group">
-            <label>郵便番号</label>
-              <%= f.text_field :post_number %>
-          </div>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div class="form-group">
-            <label>住所</label>
-              <%= f.text_field :address %>
-          </div>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div class="form-group">
-            <label>電話番号</label>
-              <%= f.text_field :phone_number %>
-          </div>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div class="form-group">
-            <label>メールアドレス</label>
-              <%= f.text_field :email %>
-          </div>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <form class="form-inline">
-          <div class="form-group">
-            <lavel></lavel>
-            <%= f.submit '編集内容を保存', class: "btn btn-success" %>
-            <%= link_to "退会する", unsubscribe_members_path(@member), class: "btn btn-danger" %>
-          </div>
-          </form>
-        </td>
-      </tr>
-    <% end %>
+    <tr>
+      <td>
+        <div class="form-group">
+          <label>氏名</label>
+            <%= f.text_field :last_name %>
+             <%= f.text_field :first_name %>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <div class="form-group">
+          <label>フリガナ</label>
+            <%= f.text_field :last_name_kana %>
+            <%= f.text_field :first_name_kana %>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <div class="form-group">
+          <label>郵便番号</label>
+            <%= f.text_field :post_number %>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <div class="form-group">
+          <label>住所</label>
+            <%= f.text_field :address %>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <div class="form-group">
+          <label>電話番号</label>
+            <%= f.text_field :phone_number %>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <div class="form-group">
+          <label>メールアドレス</label>
+            <%= f.text_field :email %>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <div class="form-group">
+          <lavel></lavel>
+          <%= f.submit '編集内容を保存', class: "btn btn-success" %>
+          <%= link_to "退会する", unsubscribe_members_path(@member), class: "btn btn-danger" %>
+        </div>
+      </td>
+    </tr>
   </tbody>
 </table>
 <% end %>

--- a/app/views/public/members/show.html.erb
+++ b/app/views/public/members/show.html.erb
@@ -14,10 +14,10 @@
       <table class="table-bordered justify-content-between">
         <tbody>
           <tr>
-            <th>会員ID</th><td><%= @member.id%></td>
+            <th>氏名</th><td><%= @member.last_name %> <%= @member.first_name %></td>
           </tr>
           <tr>
-            <th>フリガナ</th><td><%= @member.last_name_kana %><%= @member.first_name_kana%></td>
+            <th>フリガナ</th><td><%= @member.last_name_kana %> <%= @member.first_name_kana %></td>
           </tr>
           <tr>
             <th>郵便番号</th><td><%= @member.post_number %></td>

--- a/app/views/public/members/unsubscribe.html.erb
+++ b/app/views/public/members/unsubscribe.html.erb
@@ -1,15 +1,12 @@
-<% if false %>
 <h2>本当に退会しますか？</h2>
  <p>
    退会すると、会員登録情報や<br />
    これまでの購入履歴が閲覧できなくなります。<br />
    退会する場合は、「退会する」をクリックしてください。
  </p>
-    <%= link_to member_path(@member), class: 'btn btn-sm btn-primary' do %>
+    <%= link_to member_path(current_member), class: 'btn btn-sm btn-primary' do %>
       <span>退会しない</span>
     <% end %>
-    <%= link_to addresses_path(@member), class: 'btn btn-sm btn-danger' do %>
+    <%= link_to withdraw_members_path(current_member), method: :patch, class: 'btn btn-sm btn-danger' do %>
       <span>退会する</span>
     <% end %>
-<% end %>
-    

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
     resources :members, only: [:show, :edit, :update] do
       collection do
         get :unsubscribe
-        get :withdraw
+        patch :withdraw
       end
     end
   end


### PR DESCRIPTION
1.退会処理の実装をpublic_member_sessionのviewに追加、memberモデルも編集
  public_member_のコントローラー、viewを作成、編集（退会機能関係）
2.ヘッダーのbootstrap適用を実施、homes-about,topのviewも同様に作成中
