### PR TITLE
退会フラグの修正

### DIFF
--- a/app/controllers/admin/homes_controller.rb
+++ b/app/controllers/admin/homes_controller.rb
@@ -1,4 +1,5 @@
 class Admin::HomesController < ApplicationController
+  before_action :authenticate_admin!,except: [:sign_in]
   def top
     @orders = Order.all.page(params[:page])
   end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -2,6 +2,7 @@
 
 class Admin::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
+  before_action :authenticate_member!
   def after_sign_out_path_for(resource)
     admin_root_path
   end

--- a/app/controllers/public/members_controller.rb
+++ b/app/controllers/public/members_controller.rb
@@ -23,7 +23,7 @@ class Public::MembersController < ApplicationController
     @member = current_member
     @member.update(is_deleted: true)
     reset_session
-    flash[:nitice] = "またのご利用をお待ちしております。"
+    flash[:notice] = "またのご利用をお待ちしております。"
     redirect_to root_path
   end
 

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -3,7 +3,7 @@
 class Public::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
   before_action :member_state, only: [:create]
-  
+
   def after_sign_in_path_for(resource)
     root_path
   end
@@ -26,15 +26,13 @@ class Public::SessionsController < Devise::SessionsController
   # end
 
   protected
-  
+
   def member_state
     @member = Member.find_by(email: params[:member][:email])
-    if @member
-      if @member.valid_password?(params[:member][:password]) && (@member.is_deleted == false)
+    return if !@member
+    if @member.valid_password?(params[:member][:password]) && (@member.is_deleted == false)
         flash[:notice] = "既に退会されています。再度ご登録をお願いします。"
         redirect_to new_member_registration_path
-      else
-      end
     end
   end
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -7,12 +7,16 @@ class Member < ApplicationRecord
   has_many :cart_items, dependent: :destroy
   has_many :orders, dependent: :destroy
   has_many :addresses, dependent: :destroy
+
   validates :is_deleted, inclusion: { in: [true, false] }
-  validates :last_name,:first_name,:address, presence: true,
+  validates :last_name,:first_name, presence: true,
     length: {in: 1..20 }
   validates :last_name_kana,:first_name_kana, format: {with: /\A[ァ-ヶー－]+\z/ , message: "カタカナで入力してください。"},
     length: {in: 1..20 }
+  validates :address, presence: true
   validates :post_number, format: {with: /\A\d{7}\z/ , message: "ハイフンなしの７桁で入力してください。"}
+  validates :phone_number, format: {with: /\A\d{10,11}\z/ , message: "ハイフンなしで入力してください。"}
+
   def active_for_authentication?
     super && (is_deleted == false)
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
     <header>
       <div class="container-fluid bg-light">
         <div class="row justify-content-between">
-          <a class="navbar-brand col-auto mr-auto p-3 m-0" href="/"><%= image_tag('logo.png', :size =>'80x80') %></a>
+          <a class="col-auto mr-auto p-3 m-0" href="/"><%= image_tag('logo.png', :size =>'80x80') %></a>
           <div class="col-md-lg-auto mr-3 align-self-center">
             <% if member_signed_in? %>
             <button class= "btn btn-outline-secondary mr-3">
@@ -50,7 +50,7 @@
               <%= link_to "About", about_path, class: "text-dark" %>
             </button>
             <button class= "btn btn-outline-secondary mr-3">
-              <%= link_to "商品一覧", items_path, class: "text-dark" %>
+              <%= link_to "商品一覧", root_path, class: "text-dark" %>
             </button>
             <button class= "btn btn-outline-secondary mr-3">
               <%= link_to "新規登録", new_member_registration_path, class: "text-dark" %>

--- a/app/views/public/homes/about.html.erb
+++ b/app/views/public/homes/about.html.erb
@@ -1,12 +1,12 @@
 <main>
   <div class="container">
-    <div class="row-mt-5">
-      <h1 class="mx-auto center-block">
+    <div class="row my-5 justify-content-center">
+      <h1>
         <strong>About</strong>
       </h1>
     </div>
-    <div class="row">
-      <p class="mx-auto text-center">
+    <div class="row mb-2 justify-content-center">
+      <p class="text-center fw-bold">
         ながのCAKEは全国発送可能なケーキ屋です。<br />
         お子様からお年寄りの方までお召し上がりいただけるよう、<br />
         様々なバリエーションをご用意しております。<br />

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -1,12 +1,10 @@
 <main>
-  <p></p>
-  <div class="container">
     <div class="row">
-      <div class="col-2 text-center">
+      <div class="col-lg-2 text-center">
         ジャンル検索
       </div>
-      <div class="col-8">
-        <p class="mx-auto my-5 text-center">
+      <div class="col-lg-8">
+        <p class="mx-auto my-5 fw-bold">
           ようこそながのCAKEへ！！<br />
           このサイトは、ケーキ販売のECサイトになります。<br />
           会員でない方も商品の閲覧はできますが、<br />
@@ -29,6 +27,5 @@
       </div>
     <% end %>
     </div>
-  </div>
 </main>
-  
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,98 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2022_01_18_075517) do
+
+  create_table "addresses", force: :cascade do |t|
+    t.string "name"
+    t.string "post_number"
+    t.string "address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "admins", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admins_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "cart_items", force: :cascade do |t|
+    t.integer "count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "genres", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "item_orders", force: :cascade do |t|
+    t.integer "price"
+    t.integer "count"
+    t.integer "making_status", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "items", force: :cascade do |t|
+    t.string "name"
+    t.text "introduction"
+    t.integer "price"
+    t.string "image_id"
+    t.integer "sales_status", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "genre_id"
+  end
+
+  create_table "members", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.string "last_name"
+    t.string "first_name"
+    t.string "last_name_kana"
+    t.string "first_name_kana"
+    t.string "phone_number"
+    t.string "post_number"
+    t.string "address"
+    t.boolean "is_deleted", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_members_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_members_on_reset_password_token", unique: true
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.string "post_number"
+    t.string "address"
+    t.string "name"
+    t.integer "postage"
+    t.integer "total_payment"
+    t.integer "payment_methods", default: 0
+    t.integer "order_status", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end


### PR DESCRIPTION
1.退会フラグの論理削除機能の修正
　原因：おそらく、is_deleteのカラムがtrueの会員をはじく必要があるのに、falseの会員をはじいてしまっている可能性
　　　　論理式の記述を確認し、修正を行う。